### PR TITLE
add exit_ca_mode to reset

### DIFF
--- a/progs/reset_cmd.c
+++ b/progs/reset_cmd.c
@@ -547,6 +547,9 @@ send_init_strings(int fd GCC_UNUSED, TTY * old_settings)
 				  ? reset_2string
 				  : init_2string);
 
+	/* return to main buffer */
+	need_flush |= sent_string(exit_ca_mode);
+
 	if (VALID_STRING(clear_margins)) {
 	    need_flush |= sent_string(clear_margins);
 	}


### PR DESCRIPTION
add exit_ca_mode to reset

resetting the terminal means returning to the main buffer

this is equivalent to

~~~
tput te
echo -e "\e[?1047l"
~~~

# disable mouse

i placed this after reset_2string that disable mouse input for bash that dislike that

for me this is equivalent to

~~~
echo -e "\e[?1002l"
~~~

# crash

this is a typical necessity after crashes in bash both directly in the emulator and inside tmux with mouse support 

~~~
alias mouse='echo -e "\e[?1002l";tput te'
~~~

# test

i have no test program for this but my mcedit has a bug that allows me to test it. pressing help and left crashes back to bash without restoring the buffer or mouse flags

